### PR TITLE
Fix radar display not showing player/opponent icons   

### DIFF
--- a/src/radar.ts
+++ b/src/radar.ts
@@ -68,10 +68,6 @@ export const cleanUpRadarDisplay = () => {
   }
 };
 
-const distance = (x: number, y: number, v: number, w: number) => {
-  return Math.sqrt((x - v) * (x - v) + (y - w) * (y - w));
-};
-
 export const updateRadarDisplay = (
   screen: Surface,
   playerX: number,
@@ -107,18 +103,17 @@ export const updateRadarDisplay = (
   };
 
   // figure the x, y by scaling the player x, y
+  const scaledPlayerX = (playerX / (g.WORLD_WIDTH / 100)) | 0;
+  const scaledPlayerY = (playerY / (g.WORLD_HEIGHT / 100)) | 0;
+
   let destCoord: Coord = {
-    x: ((playerX / (g.WORLD_WIDTH / 100)) | 0) + radar.physicX,
-    y: ((playerY / (g.WORLD_HEIGHT / 100)) | 0) + radar.physicY,
+    x: scaledPlayerX + radar.physicX,
+    y: scaledPlayerY + radar.physicY,
   };
 
   if (
-    distance(
-      playerX / (g.WORLD_WIDTH / 100),
-      playerY / (g.WORLD_HEIGHT / 100),
-      50,
-      50
-    ) < 8
+    scaledPlayerX >= 0 && scaledPlayerX < radar.physicW &&
+    scaledPlayerY >= 0 && scaledPlayerY < radar.physicH
   ) {
     // draw player icon
     SURF.blitSurface(radar.playerIcon, playerBlobSrcRect, screen, destCoord);
@@ -135,16 +130,15 @@ export const updateRadarDisplay = (
   };
 
   // figure the x and y of the blob by scaling the x and y of opponent
-  destCoord.x = ((oppX / (g.WORLD_WIDTH / 100)) | 0) + radar.physicX;
-  destCoord.y = ((oppY / (g.WORLD_HEIGHT / 100)) | 0) + radar.physicY;
+  const scaledOppX = (oppX / (g.WORLD_WIDTH / 100)) | 0;
+  const scaledOppY = (oppY / (g.WORLD_HEIGHT / 100)) | 0;
+
+  destCoord.x = scaledOppX + radar.physicX;
+  destCoord.y = scaledOppY + radar.physicY;
 
   if (
-    distance(
-      oppX / (g.WORLD_WIDTH / 100),
-      oppY / (g.WORLD_HEIGHT / 100),
-      50,
-      50
-    ) < 8
+    scaledOppX >= 0 && scaledOppX < radar.physicW &&
+    scaledOppY >= 0 && scaledOppY < radar.physicH
   ) {
     if (radar.oppIconState < 10) {
       // draw opposition icon


### PR DESCRIPTION
  Summary                                                                                                                                                                
                                                                                                                                                                         
  - The previous distance function fix (commit 7672927) corrected ^ (bitwise XOR) to proper squaring, but the visibility threshold < 8 was accidentally calibrated to the
   old buggy XOR values                                                                                                                                                  
  - With correct Euclidean distance, the threshold was far too small, causing both player and opponent icons to never appear on the radar                                
  - Replaced the distance-from-center check with a rectangular bounds check against the radar dimensions, since the radar maps the entire 2000x2000 world onto the       
  100x100 display                                                                                                                                                        
                                                                                                                                                                         
  Test plan                                                                                                                                                              
                                                                                                                                                                         
  - Verify player green LED icon appears on the radar at all world positions                                                                                             
  - Verify opponent red LED icon appears on the radar at all world positions                                                                                             
  - Verify opponent icon still blinks correctly                                                                                                                          
  - Verify radar background still renders in the bottom-left corner       